### PR TITLE
Allow to pass arguments to `createNode()`

### DIFF
--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -91,12 +91,12 @@ export interface MosaicWindowActions {
      * The current node becomes the `first` and the new node the `second` of the result.
      * `direction` is chosen by querying the DOM and splitting along the longer axis
      */
-    split: () => Promise<void>;
+    split: (...args: any[]) => Promise<void>;
     /**
      * Fails if no `createNode()` is defined
      * Convenience function to call `createNode()` and replace the current node with it.
      */
-    replaceWithNew: () => Promise<void>;
+    replaceWithNew: (...args: any[]) => Promise<void>;
 }
 
 /*************************************************************

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,7 @@ export type TileRenderer<T> = (t: T) => JSX.Element;
 /**
  * Function that provides a new node to put into the tree
  */
-export type CreateNode<T> = () => Promise<MosaicNode<T>> | MosaicNode<T>;
+export type CreateNode<T> = (...args: any[]) => Promise<MosaicNode<T>> | MosaicNode<T>;
 
 /**
  * Used by `react-dnd`

--- a/src/window/MosaicWindow.ts
+++ b/src/window/MosaicWindow.ts
@@ -230,7 +230,7 @@ class MosaicWindowClass<T> extends React.PureComponent<Props<T>, State> {
         }
     }
 
-    private split = () => {
+    private split = (...args) => {
         this.checkCreateNode();
         const { createNode } = this.props;
         const { mosaicActions, getMosaicPath } = this.context;
@@ -240,7 +240,7 @@ class MosaicWindowClass<T> extends React.PureComponent<Props<T>, State> {
         const direction: MosaicDirection =
             this.rootElement!.offsetWidth > this.rootElement!.offsetHeight ? 'row' : 'column';
 
-        return Promise.resolve(createNode!())
+        return Promise.resolve(createNode!(...args))
             .then((second) =>
                 mosaicActions.replaceWith(path, {
                     direction, second,
@@ -248,11 +248,11 @@ class MosaicWindowClass<T> extends React.PureComponent<Props<T>, State> {
                 }));
     };
 
-    private swap = () => {
+    private swap = (...args) => {
         this.checkCreateNode();
         const { mosaicActions, getMosaicPath } = this.context;
         const { createNode } = this.props;
-        return Promise.resolve(createNode!())
+        return Promise.resolve(createNode!(...args))
             .then((node) =>
                 mosaicActions.replaceWith(getMosaicPath(), node));
     };

--- a/src/window/MosaicWindow.ts
+++ b/src/window/MosaicWindow.ts
@@ -230,7 +230,7 @@ class MosaicWindowClass<T> extends React.PureComponent<Props<T>, State> {
         }
     }
 
-    private split = (...args) => {
+    private split = (...args: any[]) => {
         this.checkCreateNode();
         const { createNode } = this.props;
         const { mosaicActions, getMosaicPath } = this.context;
@@ -248,7 +248,7 @@ class MosaicWindowClass<T> extends React.PureComponent<Props<T>, State> {
                 }));
     };
 
-    private swap = (...args) => {
+    private swap = (...args: any[]) => {
         this.checkCreateNode();
         const { mosaicActions, getMosaicPath } = this.context;
         const { createNode } = this.props;


### PR DESCRIPTION
This will allow to create different windows children depending on passed arguments.

For example:
```jsx
import React from 'react'
import componentsRegistry from './componentRegistry'
import initialLayout from './initialLayout'

export default class LayoutManager extends React.Component {
  handleCreateNode = (type, props) => {
    return componentsRegistry.register(type, props).uuid
  }

  renderTile = (id) => {
    return <MosaicWindow createNode={this.handleCreateNode}>
      {componentsRegistry.render[id]}
    </MosaicWindow>
  }

  render() {
    return <Mosaic
      renderTile={this.renderTile}
      initialValue={initialLayout}
    />
  }
}

```