### PR TITLE
Flatten rendered tree for performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ for a more interesting example that shows the usage of Mosaic as a controlled co
 
 #### Mosaic Props
 ```typescript
-export interface MosaicBaseProps<T> {
+export interface MosaicBaseProps<T extends MosaicKey> {
     /**
      * Lookup function to convert `T` to a displayable `ReactElement`
      */
@@ -189,7 +189,7 @@ export interface MosaicBaseProps<T> {
     zeroStateView?: React.ReactElement<any>;
 }
 
-export interface MosaicControlledProps<T> extends MosaicBaseProps<T> {
+export interface MosaicControlledProps<T extends MosaicKey> extends MosaicBaseProps<T> {
     /**
      * The tree to render
      */
@@ -197,20 +197,20 @@ export interface MosaicControlledProps<T> extends MosaicBaseProps<T> {
     onChange: (newNode: MosaicNode<T> | null) => void;
 }
 
-export interface MosaicUncontrolledProps<T> extends MosaicBaseProps<T> {
+export interface MosaicUncontrolledProps<T extends MosaicKey> extends MosaicBaseProps<T> {
     /**
      * The initial tree to render, can be modified by the user
      */
     initialValue: MosaicNode<T> | null;
 }
 
-export type MosaicProps<T> = MosaicControlledProps<T> | MosaicUncontrolledProps<T>;
+export type MosaicProps<T extends MosaicKey> = MosaicControlledProps<T> | MosaicUncontrolledProps<T>;
 ```
 
 #### `MosaicWindow`
 
 ```typescript
-export interface MosaicWindowProps<T> {
+export interface MosaicWindowProps<T extends MosaicKey> {
     title: string;
     className?: string;
     /**
@@ -249,7 +249,7 @@ These are used extensively by `MosaicWindow`.
 export type MosaicBranch = 'first' | 'second';
 export type MosaicPath = MosaicBranch[];
 
-export interface MosaicTileContext<T> {
+export interface MosaicTileContext<T extends MosaicKey> {
     /**
      * These actions are used to alter the state of the view tree
      */
@@ -260,7 +260,7 @@ export interface MosaicTileContext<T> {
     getMosaicPath: () => MosaicPath;
 }
 
-export interface MosaicRootActions<T> {
+export interface MosaicRootActions<T extends MosaicKey> {
     /**
      * Increases the size of this node and bubbles up the tree
      * @param path Path to node to expand
@@ -298,7 +298,7 @@ export interface MosaicRootActions<T> {
 Children (and toolbar elements) within `MosaicWindow` are passed the following additional functions on context.
 
 ```typescript
-export interface MosaicWindowContext<T> extends MosaicTileContext<T> {
+export interface MosaicWindowContext<T extends MosaicKey> extends MosaicTileContext<T> {
   mosaicWindowActions: MosaicWindowActions;
 }
 
@@ -345,18 +345,18 @@ class RemoveButton extends React.PureComponent<Props> {
 ```
 
 ### Mutating the Tree
-Utilities are provided for working with the MosaicNode tree in [`mosaicUtilities`](./src/mosaicUtilities.ts) and
-[`mosaicUpdates`](./src/mosaicUpdates.ts)
+Utilities are provided for working with the MosaicNode tree in [`mosaicUtilities`](src/util/mosaicUtilities.ts) and
+[`mosaicUpdates`](src/util/mosaicUpdates.ts)
 #### MosaicUpdate
 [`MosaicUpdateSpec`](./src/types.ts#L43) is an argument meant to be passed to [`immutability-helper`](https://github.com/kolodny/immutability-helper) 
-to modify the state at a path. [`mosaicUpdates`](./src/mosaicUpdates.ts) has examples.
+to modify the state at a path. [`mosaicUpdates`](src/util/mosaicUpdates.ts) has examples.
 
 ```
 /**
  * Used by many utility methods to update the tree.
  * spec will be passed to https://github.com/kolodny/immutability-helper
  */
-export interface MosaicUpdateSpec<T> {
+export interface MosaicUpdateSpec<T extends MosaicKey> {
     $set?: MosaicNode<T>;
     splitPercentage?: {
         $set: number | null;

--- a/demo/ExampleApp.tsx
+++ b/demo/ExampleApp.tsx
@@ -51,6 +51,8 @@ const additionalControls = React.Children.toArray([
   <CloseAdditionalControlsButton/>,
 ]);
 
+const EMPTY_ARRAY: any[] = [];
+
 export interface ExampleAppState {
   currentNode: MosaicNode<number> | null;
   currentTheme: Theme;
@@ -73,11 +75,12 @@ export class ExampleApp extends React.PureComponent<{}, ExampleAppState> {
       <div className='react-mosaic-example-app'>
         {this.renderNavBar()}
         <NumberMosaic
-          renderTile={(count: number) => (
+          renderTile={(count, path) => (
             <NumberMosaicWindow
-              additionalControls={count === 3 ? additionalControls : []}
+              additionalControls={count === 3 ? additionalControls : EMPTY_ARRAY}
               title={`Window ${count}`}
               createNode={this.createNode}
+              path={path}
             >
               <div className='example-window'>
                 <h1>{`Window ${count}`}</h1>

--- a/demo/example.less
+++ b/demo/example.less
@@ -55,7 +55,7 @@ html, body, #app, .react-mosaic-example-app {
     color: @white;
   }
 
-  > .mosaic-root {
+  > .mosaic {
     height: ~"calc(100% - 50px)";
   }
 }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "uuid": "^3.0.1"
   },
   "peerDependencies": {
-    "react": "^15.0.0 || ^16.0.0"
+    "react": "^16.0.0"
   },
   "keywords": [
     "ui",

--- a/src/Mosaic.tsx
+++ b/src/Mosaic.tsx
@@ -24,13 +24,14 @@ import { MosaicContext, MosaicRootActions } from './contextTypes';
 import { MosaicDropTargetPosition } from './internalTypes';
 import { MosaicWindowDropTarget } from './MosaicDropTarget';
 import { MosaicTile } from './MosaicTile';
-import { createExpandUpdate, createHideUpdate, createRemoveUpdate, updateTree } from './mosaicUpdates';
 import { MosaicZeroState } from './MosaicZeroState';
-import { MosaicNode, MosaicPath, MosaicUpdate, ResizeOptions, TileRenderer } from './types';
+import { MosaicKey, MosaicNode, MosaicPath, MosaicUpdate, ResizeOptions, TileRenderer } from './types';
+import { BoundingBox } from './util/BoundingBox';
+import { createExpandUpdate, createHideUpdate, createRemoveUpdate, updateTree } from './util/mosaicUpdates';
 
 const DEFAULT_EXPAND_PERCENTAGE = 70;
 
-export interface MosaicBaseProps<T> {
+export interface MosaicBaseProps<T extends MosaicKey> {
   /**
    * Lookup function to convert `T` to a displayable `ReactElement`
    */
@@ -56,7 +57,7 @@ export interface MosaicBaseProps<T> {
   zeroStateView?: JSX.Element;
 }
 
-export interface MosaicControlledProps<T> extends MosaicBaseProps<T> {
+export interface MosaicControlledProps<T extends MosaicKey> extends MosaicBaseProps<T> {
   /**
    * The tree to render
    */
@@ -64,25 +65,25 @@ export interface MosaicControlledProps<T> extends MosaicBaseProps<T> {
   onChange: (newNode: MosaicNode<T> | null) => void;
 }
 
-export interface MosaicUncontrolledProps<T> extends MosaicBaseProps<T> {
+export interface MosaicUncontrolledProps<T extends MosaicKey> extends MosaicBaseProps<T> {
   /**
    * The initial tree to render, can be modified by the user
    */
   initialValue: MosaicNode<T> | null;
 }
 
-export type MosaicProps<T> = MosaicControlledProps<T> | MosaicUncontrolledProps<T>;
+export type MosaicProps<T extends MosaicKey> = MosaicControlledProps<T> | MosaicUncontrolledProps<T>;
 
-function isUncontrolled<T>(props: MosaicProps<T>): props is MosaicUncontrolledProps<T> {
+function isUncontrolled<T extends MosaicKey>(props: MosaicProps<T>): props is MosaicUncontrolledProps<T> {
   return (props as MosaicUncontrolledProps<T>).initialValue != null;
 }
 
-export interface MosaicState<T> {
+export interface MosaicState<T extends MosaicKey> {
   currentNode: MosaicNode<T> | null;
   mosaicId: string;
 }
 
-export class MosaicWithoutDragDropContext<T> extends React.PureComponent<MosaicProps<T>, MosaicState<T>> {
+export class MosaicWithoutDragDropContext<T extends MosaicKey> extends React.PureComponent<MosaicProps<T>, MosaicState<T>> {
   static defaultProps = {
     onChange: () => void 0,
     zeroStateView: <MosaicZeroState/>,
@@ -115,6 +116,7 @@ export class MosaicWithoutDragDropContext<T> extends React.PureComponent<MosaicP
           zeroStateView : React.createElement(MosaicTile, {
             node, renderTile, resize,
             getPath: this.getPath,
+            boundingBox: BoundingBox.empty(),
           })
         }
         <div className='drop-target-container'>
@@ -194,11 +196,11 @@ export class MosaicWithoutDragDropContext<T> extends React.PureComponent<MosaicP
 }
 
 @(DragDropContext(HTML5) as ClassDecorator)
-export class Mosaic<T> extends MosaicWithoutDragDropContext<T> {
+export class Mosaic<T extends MosaicKey> extends MosaicWithoutDragDropContext<T> {
 }
 
 // Factory that works with generics
-export function MosaicFactory<T>(props: MosaicProps<T> & React.Attributes, ...children: React.ReactNode[]) {
+export function MosaicFactory<T extends MosaicKey>(props: MosaicProps<T> & React.Attributes, ...children: React.ReactNode[]) {
   const element: React.ReactElement<MosaicProps<T>> =
     React.createElement(Mosaic as React.ComponentClass<MosaicProps<T>>, props, ...children);
   return element;

--- a/src/Mosaic.tsx
+++ b/src/Mosaic.tsx
@@ -32,7 +32,7 @@ const DEFAULT_EXPAND_PERCENTAGE = 70;
 
 export interface MosaicBaseProps<T extends MosaicKey> {
   /**
-   * Lookup function to convert `T` to a displayable `ReactElement`
+   * Lookup function to convert `T` to a displayable `JSX.Element`
    */
   renderTile: TileRenderer<T>;
   /**

--- a/src/MosaicRoot.tsx
+++ b/src/MosaicRoot.tsx
@@ -16,61 +16,62 @@
  */
 import * as _ from 'lodash';
 import * as React from 'react';
-import { MosaicActionsPropType, MosaicContext, } from './contextTypes';
+import { MosaicContext } from './contextTypes';
 import { Split } from './Split';
-import { MosaicBranch, MosaicDirection, MosaicKey, MosaicNode, ResizeOptions, TileRenderer, } from './types';
+import { MosaicBranch, MosaicDirection, MosaicKey, MosaicNode, ResizeOptions, TileRenderer } from './types';
 import { BoundingBox } from './util/BoundingBox';
 import { isParent } from './util/mosaicUtilities';
 
-export interface MosaicTileProps<T extends MosaicKey> {
-  node: MosaicNode<T>;
+export interface MosaicRootProps<T extends MosaicKey> {
+  root: MosaicNode<T>;
   renderTile: TileRenderer<T>;
   resize?: ResizeOptions;
-  className?: string;
 }
 
-function nonNullElement(x: JSX.Element | null): x is JSX.Element {
-  return x !== null;
-}
-
-export class MosaicTile<T extends MosaicKey> extends React.Component<MosaicTileProps<T>> {
+export class MosaicRoot<T extends MosaicKey> extends React.PureComponent<MosaicRootProps<T>> {
+  static contextTypes = MosaicContext;
   context: MosaicContext<T>;
 
-  static contextTypes = {
-    mosaicActions: MosaicActionsPropType,
-  };
-
   render() {
-    const { node } = this.props;
-    return this.renderRecursively(node, BoundingBox.empty(), []);
+    const { root } = this.props;
+    return (
+      <div className='mosaic-root'>
+        {this.renderRecursively(root, BoundingBox.empty(), [])}
+      </div>
+    );
   }
 
-  shouldComponentUpdate(nextProps: MosaicTileProps<T>) {
-    // Deep equal for `boundingBox`
-    return !_.isEqual(this.props, nextProps);
-  }
-
-  private renderRecursively(node: MosaicNode<T>, boundingBox: BoundingBox, path: MosaicBranch[]): JSX.Element[] {
+  private renderRecursively(node: MosaicNode<T>, boundingBox: BoundingBox, path: MosaicBranch[]): JSX.Element | JSX.Element[] {
     if (isParent(node)) {
       const splitPercentage = node.splitPercentage == null ? 50 : node.splitPercentage;
-      const { first, splitter, second } = BoundingBox.split(boundingBox, splitPercentage, node.direction);
+      const { first, second } = BoundingBox.split(boundingBox, splitPercentage, node.direction);
       return _.flatten([
         this.renderRecursively(node.first, first, path.concat('first')),
-        this.renderSplit(node.direction, splitter, path),
+        this.renderSplit(node.direction, boundingBox, splitPercentage, path),
         this.renderRecursively(node.second, second, path.concat('second')),
       ].filter(nonNullElement));
     } else {
-      return [<div className='mosaic-tile'>{this.props.renderTile(node, path)}</div>];
+      return (
+        <div
+          key={node}
+          className='mosaic-tile'
+          style={{ ...BoundingBox.asStyles(boundingBox) }}
+        >
+          {this.props.renderTile(node, path)}
+        </div>
+      );
     }
   }
 
-  private renderSplit(direction: MosaicDirection, splitBoundingBox: BoundingBox, path: MosaicBranch[]) {
+  private renderSplit(direction: MosaicDirection, boundingBox: BoundingBox, splitPercentage: number, path: MosaicBranch[]) {
     const { resize } = this.props;
     if (resize !== 'DISABLED') {
       return (
         <Split
+          key={path.join(',') + 'splitter'}
           {...resize}
-          boundingBox={splitBoundingBox}
+          boundingBox={boundingBox}
+          splitPercentage={splitPercentage}
           direction={direction}
           onChange={(percentage) => this.onResize(percentage, path)}
         />
@@ -89,4 +90,8 @@ export class MosaicTile<T extends MosaicKey> extends React.Component<MosaicTileP
       },
     }]);
   };
+}
+
+function nonNullElement(x: JSX.Element | null): x is JSX.Element {
+  return x !== null;
 }

--- a/src/MosaicWindow.tsx
+++ b/src/MosaicWindow.tsx
@@ -23,12 +23,12 @@ import { Separator } from './buttons/Separator';
 import { MosaicTileContext, MosaicWindowActionsPropType, MosaicWindowContext } from './contextTypes';
 import { MosaicDragItem, MosaicDropData, MosaicDropTargetPosition } from './internalTypes';
 import { MosaicWindowDropTarget } from './MosaicDropTarget';
-import { createDragToUpdates } from './mosaicUpdates';
-import { getAndAssertNodeAtPathExists } from './mosaicUtilities';
-import { CreateNode, MosaicDirection, MosaicDragType } from './types';
+import { CreateNode, MosaicDirection, MosaicDragType, MosaicKey } from './types';
+import { createDragToUpdates } from './util/mosaicUpdates';
+import { getAndAssertNodeAtPathExists } from './util/mosaicUtilities';
 import DragSourceMonitor = __ReactDnd.DragSourceMonitor;
 
-export interface MosaicWindowProps<T> {
+export interface MosaicWindowProps<T extends MosaicKey> {
   title: string;
   className?: string;
   toolbarControls?: React.ReactNode;
@@ -50,13 +50,16 @@ export interface InternalDropTargetProps {
   draggedMosaicId: string | undefined;
 }
 
-export type InternalMosaicWindowProps<T> = MosaicWindowProps<T> & InternalDropTargetProps & InternalDragSourceProps;
+export type InternalMosaicWindowProps<T extends MosaicKey> =
+  MosaicWindowProps<T>
+  & InternalDropTargetProps
+  & InternalDragSourceProps;
 
 export interface InternalMosaicWindowState {
   additionalControlsOpen: boolean;
 }
 
-export class InternalMosaicWindow<T> extends React.PureComponent<InternalMosaicWindowProps<T>, InternalMosaicWindowState> {
+export class InternalMosaicWindow<T extends MosaicKey> extends React.PureComponent<InternalMosaicWindowProps<T>, InternalMosaicWindowState> {
   static defaultProps: Partial<InternalMosaicWindowProps<any>> = {
     additionalControlButtonText: 'More',
     draggable: true,
@@ -282,14 +285,14 @@ export const SourceDropConnectedInternalMosaicWindow = DropTarget(MosaicDragType
   draggedMosaicId: ((monitor.getItem() || {}) as MosaicDragItem).mosaicId,
 }))(SourceConnectedInternalMosaicWindow);
 
-export class MosaicWindow<T> extends React.PureComponent<MosaicWindowProps<T>> {
+export class MosaicWindow<T extends MosaicKey> extends React.PureComponent<MosaicWindowProps<T>> {
   render() {
     return <SourceDropConnectedInternalMosaicWindow {...this.props as InternalMosaicWindowProps<T>}/>;
   }
 }
 
 // Factory that works with generics
-export function MosaicWindowFactory<T>(props: MosaicWindowProps<T> & React.Attributes, ...children: React.ReactNode[]) {
+export function MosaicWindowFactory<T extends MosaicKey>(props: MosaicWindowProps<T> & React.Attributes, ...children: React.ReactNode[]) {
   const element: React.ReactElement<MosaicWindowProps<T>> = React.createElement(
     InternalMosaicWindow as React.ComponentClass<MosaicWindowProps<T>>, props, ...children);
   return element;

--- a/src/MosaicWindow.tsx
+++ b/src/MosaicWindow.tsx
@@ -20,16 +20,17 @@ import * as React from 'react';
 import { ConnectDragPreview, ConnectDragSource, ConnectDropTarget, DragSource, DropTarget } from 'react-dnd';
 import { DEFAULT_CONTROLS_WITH_CREATION, DEFAULT_CONTROLS_WITHOUT_CREATION } from './buttons/defaultToolbarControls';
 import { Separator } from './buttons/Separator';
-import { MosaicTileContext, MosaicWindowActionsPropType, MosaicWindowContext } from './contextTypes';
+import { MosaicContext, MosaicWindowActionsPropType, MosaicWindowContext } from './contextTypes';
 import { MosaicDragItem, MosaicDropData, MosaicDropTargetPosition } from './internalTypes';
 import { MosaicWindowDropTarget } from './MosaicDropTarget';
-import { CreateNode, MosaicDirection, MosaicDragType, MosaicKey } from './types';
+import { CreateNode, MosaicBranch, MosaicDirection, MosaicDragType, MosaicKey } from './types';
 import { createDragToUpdates } from './util/mosaicUpdates';
 import { getAndAssertNodeAtPathExists } from './util/mosaicUtilities';
 import DragSourceMonitor = __ReactDnd.DragSourceMonitor;
 
 export interface MosaicWindowProps<T extends MosaicKey> {
   title: string;
+  path: MosaicBranch[];
   className?: string;
   toolbarControls?: React.ReactNode;
   additionalControls?: React.ReactNode;
@@ -59,7 +60,15 @@ export interface InternalMosaicWindowState {
   additionalControlsOpen: boolean;
 }
 
-export class InternalMosaicWindow<T extends MosaicKey> extends React.PureComponent<InternalMosaicWindowProps<T>, InternalMosaicWindowState> {
+const PURE_RENDER_IGNORE: (keyof InternalMosaicWindowProps<any> | 'children')[] = [
+  'path',
+  'connectDropTarget',
+  'connectDragSource',
+  'connectDragPreview',
+  'children',
+];
+
+export class InternalMosaicWindow<T extends MosaicKey> extends React.Component<InternalMosaicWindowProps<T>, InternalMosaicWindowState> {
   static defaultProps: Partial<InternalMosaicWindowProps<any>> = {
     additionalControlButtonText: 'More',
     draggable: true,
@@ -76,7 +85,7 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.PureCompone
     ),
   };
 
-  static contextTypes = MosaicTileContext;
+  static contextTypes = MosaicContext;
 
   static childContextTypes = {
     mosaicWindowActions: MosaicWindowActionsPropType,
@@ -85,7 +94,7 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.PureCompone
   state: InternalMosaicWindowState = {
     additionalControlsOpen: false,
   };
-  context: MosaicTileContext<T>;
+  context: MosaicContext<T>;
 
   private rootElement: HTMLElement | null;
 
@@ -95,6 +104,7 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.PureCompone
         split: this.split,
         replaceWithNew: this.swap,
         setAdditionalControlsOpen: this.setAdditionalControlsOpen,
+        getPath: this.getPath,
       },
     };
   }
@@ -130,6 +140,10 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.PureCompone
     );
   }
 
+  shouldComponentUpdate(nextProps: InternalMosaicWindowProps<T>): boolean {
+    return !_.isEqual(_.omit(this.props, PURE_RENDER_IGNORE), _.omit(nextProps, PURE_RENDER_IGNORE));
+  }
+
   private getToolbarControls() {
     const { toolbarControls, createNode } = this.props;
     if (toolbarControls) {
@@ -144,7 +158,7 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.PureCompone
   private renderToolbar() {
     const {
       title, draggable, additionalControls, additionalControlButtonText,
-      connectDragSource,
+      connectDragSource, path,
     } = this.props;
     const { additionalControlsOpen } = this.state;
     const toolbarControls = this.getToolbarControls();
@@ -158,7 +172,7 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.PureCompone
       </div>
     );
 
-    const draggableAndNotRoot = draggable && this.context.getMosaicPath().length > 0;
+    const draggableAndNotRoot = draggable && path.length > 0;
     if (draggableAndNotRoot) {
       titleDiv = connectDragSource(titleDiv) as React.ReactElement<any>;
     }
@@ -189,7 +203,7 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.PureCompone
   }
 
   private renderDropTarget = (position: MosaicDropTargetPosition) => {
-    const path = this.context.getMosaicPath();
+    const { path } = this.props;
 
     return (
       <MosaicWindowDropTarget
@@ -208,10 +222,9 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.PureCompone
 
   private split = (...args: any[]) => {
     this.checkCreateNode();
-    const { createNode } = this.props;
-    const { mosaicActions, getMosaicPath } = this.context;
+    const { createNode, path } = this.props;
+    const { mosaicActions } = this.context;
     const root = mosaicActions.getRoot();
-    const path = getMosaicPath();
 
     const direction: MosaicDirection =
       this.rootElement!.offsetWidth > this.rootElement!.offsetHeight ? 'row' : 'column';
@@ -226,40 +239,46 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.PureCompone
 
   private swap = (...args: any[]) => {
     this.checkCreateNode();
-    const { mosaicActions, getMosaicPath } = this.context;
-    const { createNode } = this.props;
+    const { mosaicActions } = this.context;
+    const { createNode, path } = this.props;
     return Promise.resolve(createNode!(...args))
       .then((node) =>
-        mosaicActions.replaceWith(getMosaicPath(), node));
+        mosaicActions.replaceWith(path, node));
   };
 
   private setAdditionalControlsOpen = (additionalControlsOpen: boolean) => {
     this.setState({ additionalControlsOpen });
   };
+
+  private getPath = () => this.props.path;
+
 }
 
 const dragSource = {
-  beginDrag: (_props: InternalMosaicWindowProps<any>, _monitor: DragSourceMonitor, { context }: InternalMosaicWindow<any>): MosaicDragItem => {
+  beginDrag: (_props: InternalMosaicWindowProps<any>, _monitor: DragSourceMonitor, component: InternalMosaicWindow<any>): MosaicDragItem => {
+    // TODO: Actually just delete instead of hiding
     // The defer is necessary as the element must be present on start for HTML DnD to not cry
-    const hideTimer = _.defer(() => context.mosaicActions.hide(context.getMosaicPath()));
+    const hideTimer = _.defer(() => component.context.mosaicActions.hide(component.props.path));
     return {
-      mosaicId: context.mosaicId,
+      mosaicId: component.context.mosaicId,
       hideTimer,
     };
   },
-  endDrag: (_props: InternalMosaicWindowProps<any>, monitor: DragSourceMonitor, { context }: InternalMosaicWindow<any>) => {
+  endDrag: (_props: InternalMosaicWindowProps<any>, monitor: DragSourceMonitor, component: InternalMosaicWindow<any>) => {
     const { hideTimer } = monitor.getItem() as MosaicDragItem;
     // If the hide call hasn't happened yet, cancel it
     window.clearTimeout(hideTimer);
 
-    const ownPath = context.getMosaicPath();
+    const ownPath = component.props.path;
     const dropResult: MosaicDropData = (monitor.getDropResult() || {}) as MosaicDropData;
+    const { mosaicActions } = component.context;
     const { position, path: destinationPath } = dropResult;
     if (position != null && destinationPath != null && !_.isEqual(destinationPath, ownPath)) {
-      context.mosaicActions.updateTree(
-        createDragToUpdates(context.mosaicActions.getRoot(), ownPath, destinationPath, position));
+      mosaicActions.updateTree(
+        createDragToUpdates(mosaicActions.getRoot(), ownPath, destinationPath, position));
     } else {
-      context.mosaicActions.updateTree([{
+      // TODO: restore node from captured state
+      mosaicActions.updateTree([{
         path: _.dropRight(ownPath),
         spec: {
           splitPercentage: {
@@ -285,14 +304,14 @@ export const SourceDropConnectedInternalMosaicWindow = DropTarget(MosaicDragType
   draggedMosaicId: ((monitor.getItem() || {}) as MosaicDragItem).mosaicId,
 }))(SourceConnectedInternalMosaicWindow);
 
-export class MosaicWindow<T extends MosaicKey> extends React.PureComponent<MosaicWindowProps<T>> {
+export class MosaicWindow<T extends MosaicKey = string> extends React.PureComponent<MosaicWindowProps<T>> {
   render() {
     return <SourceDropConnectedInternalMosaicWindow {...this.props as InternalMosaicWindowProps<T>}/>;
   }
 }
 
 // Factory that works with generics
-export function MosaicWindowFactory<T extends MosaicKey>(props: MosaicWindowProps<T> & React.Attributes, ...children: React.ReactNode[]) {
+export function MosaicWindowFactory<T extends MosaicKey = string>(props: MosaicWindowProps<T> & React.Attributes, ...children: React.ReactNode[]) {
   const element: React.ReactElement<MosaicWindowProps<T>> = React.createElement(
     InternalMosaicWindow as React.ComponentClass<MosaicWindowProps<T>>, props, ...children);
   return element;

--- a/src/MosaicZeroState.tsx
+++ b/src/MosaicZeroState.tsx
@@ -17,13 +17,13 @@
 import * as _ from 'lodash';
 import * as React from 'react';
 import { MosaicActionsPropType, MosaicContext } from './contextTypes';
-import { CreateNode } from './types';
+import { CreateNode, MosaicKey } from './types';
 
-export interface MosaicZeroStateProps<T> {
+export interface MosaicZeroStateProps<T extends MosaicKey> {
   createNode?: CreateNode<T>;
 }
 
-export class MosaicZeroState<T> extends React.PureComponent<MosaicZeroStateProps<T>> {
+export class MosaicZeroState<T extends MosaicKey> extends React.PureComponent<MosaicZeroStateProps<T>> {
   context: MosaicContext<T>;
 
   static contextTypes = {
@@ -58,7 +58,7 @@ export class MosaicZeroState<T> extends React.PureComponent<MosaicZeroStateProps
 }
 
 // Factory that works with generics
-export function MosaicZeroStateFactory<T>(props?: MosaicZeroStateProps<T> & React.Attributes, ...children: React.ReactNode[]) {
+export function MosaicZeroStateFactory<T extends MosaicKey>(props?: MosaicZeroStateProps<T> & React.Attributes, ...children: React.ReactNode[]) {
   const element: React.ReactElement<MosaicZeroStateProps<T>> = React.createElement(
     MosaicZeroState as React.ComponentClass<MosaicZeroStateProps<T>>, props, ...children);
   return element;

--- a/src/Split.tsx
+++ b/src/Split.tsx
@@ -17,12 +17,13 @@
 import * as _ from 'lodash';
 import * as React from 'react';
 import { EnabledResizeOptions, MosaicDirection } from './types';
+import { BoundingBox } from './util/BoundingBox';
 
 const RESIZE_THROTTLE_MS = 1000 / 30; // 30 fps
 
 export interface SplitProps extends EnabledResizeOptions {
   direction: MosaicDirection;
-  splitPercentage: number;
+  boundingBox: BoundingBox;
   onChange?: (percentOfParent: number) => void;
   onRelease?: (percentOfParent: number) => void;
 }

--- a/src/buttons/ExpandButton.tsx
+++ b/src/buttons/ExpandButton.tsx
@@ -28,7 +28,7 @@ export class ExpandButton<T extends MosaicKey> extends React.PureComponent<Mosai
   }
 
   private expand = () => {
-    this.context.mosaicActions.expand(this.context.getMosaicPath());
+    this.context.mosaicActions.expand(this.context.mosaicWindowActions.getPath());
 
     if (this.props.onClick) {
       this.props.onClick();

--- a/src/buttons/ExpandButton.tsx
+++ b/src/buttons/ExpandButton.tsx
@@ -16,9 +16,10 @@
  */
 import * as React from 'react';
 import { MosaicWindowContext } from '../contextTypes';
+import { MosaicKey } from '../types';
 import { createDefaultToolbarButton, MosaicButtonProps } from './MosaicButton';
 
-export class ExpandButton<T> extends React.PureComponent<MosaicButtonProps> {
+export class ExpandButton<T extends MosaicKey> extends React.PureComponent<MosaicButtonProps> {
   static contextTypes = MosaicWindowContext;
   context: MosaicWindowContext<T>;
 

--- a/src/buttons/RemoveButton.tsx
+++ b/src/buttons/RemoveButton.tsx
@@ -28,7 +28,7 @@ export class RemoveButton<T extends MosaicKey> extends React.PureComponent<Mosai
   }
 
   private remove = () => {
-    this.context.mosaicActions.remove(this.context.getMosaicPath());
+    this.context.mosaicActions.remove(this.context.mosaicWindowActions.getPath());
     if (this.props.onClick) {
       this.props.onClick();
     }

--- a/src/buttons/RemoveButton.tsx
+++ b/src/buttons/RemoveButton.tsx
@@ -16,9 +16,10 @@
  */
 import * as React from 'react';
 import { MosaicWindowContext } from '../contextTypes';
+import { MosaicKey } from '../types';
 import { createDefaultToolbarButton, MosaicButtonProps } from './MosaicButton';
 
-export class RemoveButton<T> extends React.PureComponent<MosaicButtonProps> {
+export class RemoveButton<T extends MosaicKey> extends React.PureComponent<MosaicButtonProps> {
   static contextTypes = MosaicWindowContext;
   context: MosaicWindowContext<T>;
 

--- a/src/buttons/ReplaceButton.tsx
+++ b/src/buttons/ReplaceButton.tsx
@@ -17,9 +17,10 @@
 import * as _ from 'lodash';
 import * as React from 'react';
 import { MosaicWindowContext } from '../contextTypes';
+import { MosaicKey } from '../types';
 import { createDefaultToolbarButton, MosaicButtonProps } from './MosaicButton';
 
-export class ReplaceButton<T> extends React.PureComponent<MosaicButtonProps> {
+export class ReplaceButton<T extends MosaicKey> extends React.PureComponent<MosaicButtonProps> {
   static contextTypes = MosaicWindowContext;
   context: MosaicWindowContext<T>;
 

--- a/src/buttons/SplitButton.tsx
+++ b/src/buttons/SplitButton.tsx
@@ -17,9 +17,10 @@
 import * as _ from 'lodash';
 import * as React from 'react';
 import { MosaicWindowContext } from '../contextTypes';
+import { MosaicKey } from '../types';
 import { createDefaultToolbarButton, MosaicButtonProps } from './MosaicButton';
 
-export class SplitButton<T> extends React.PureComponent<MosaicButtonProps> {
+export class SplitButton<T extends MosaicKey> extends React.PureComponent<MosaicButtonProps> {
   static contextTypes = MosaicWindowContext;
   context: MosaicWindowContext<T>;
 

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -94,7 +94,7 @@ export interface MosaicWindowActions {
   /**
    * Returns the path to this window
    */
-  getMosaicPath: () => MosaicPath;
+  getPath: () => MosaicPath;
 }
 
 /*************************************************************
@@ -114,7 +114,7 @@ export const MosaicWindowActionsPropType = PropTypes.shape({
   split: PropTypes.func.isRequired,
   replaceWithNew: PropTypes.func.isRequired,
   setAdditionalControlsOpen: PropTypes.func.isRequired,
-  getMosaicPath: PropTypes.func.isRequired,
+  getPath: PropTypes.func.isRequired,
 }).isRequired;
 
 /*************************************************************

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 import * as PropTypes from 'prop-types';
-import { MosaicNode, MosaicPath, MosaicUpdate } from './types';
+import { MosaicKey, MosaicNode, MosaicPath, MosaicUpdate } from './types';
 
 /**
  * Mosaic provides functionality on the context for components within
@@ -25,32 +25,22 @@ import { MosaicNode, MosaicPath, MosaicUpdate } from './types';
 /**
  * Context provided to everything within Mosaic
  */
-export interface MosaicContext<T> {
+export interface MosaicContext<T extends MosaicKey> {
   mosaicActions: MosaicRootActions<T>;
   mosaicId: string;
 }
 
 /**
- * Context provided to everything within a Mosaic Tile
- */
-export interface MosaicTileContext<T> extends MosaicContext<T> {
-  /**
-   * Returns the path to this tile
-   */
-  getMosaicPath: () => MosaicPath;
-}
-
-/**
  * Context provided to everything within a Mosaic Window
  */
-export interface MosaicWindowContext<T> extends MosaicTileContext<T> {
+export interface MosaicWindowContext<T extends MosaicKey> extends MosaicContext<T> {
   mosaicWindowActions: MosaicWindowActions;
 }
 
 /**
  * These actions are used to alter the state of the view tree
  */
-export interface MosaicRootActions<T> {
+export interface MosaicRootActions<T extends MosaicKey> {
   /**
    * Increases the size of this node and bubbles up the tree
    * @param path Path to node to expand
@@ -101,6 +91,10 @@ export interface MosaicWindowActions {
    * Sets the open state for the tray that holds additional controls
    */
   setAdditionalControlsOpen: (open: boolean) => void;
+  /**
+   * Returns the path to this window
+   */
+  getMosaicPath: () => MosaicPath;
 }
 
 /*************************************************************
@@ -116,12 +110,11 @@ export const MosaicActionsPropType = PropTypes.shape({
   getRoot: PropTypes.func.isRequired,
 }).isRequired;
 
-export const MosaicPathGetterPropType = PropTypes.func.isRequired;
-
 export const MosaicWindowActionsPropType = PropTypes.shape({
   split: PropTypes.func.isRequired,
   replaceWithNew: PropTypes.func.isRequired,
   setAdditionalControlsOpen: PropTypes.func.isRequired,
+  getMosaicPath: PropTypes.func.isRequired,
 }).isRequired;
 
 /*************************************************************
@@ -133,12 +126,7 @@ export const MosaicContext = {
   mosaicId: PropTypes.string.isRequired,
 };
 
-export const MosaicTileContext = {
-  ...MosaicContext,
-  getMosaicPath: MosaicPathGetterPropType,
-};
-
 export const MosaicWindowContext = {
-  ...MosaicTileContext,
+  ...MosaicContext,
   mosaicWindowActions: MosaicWindowActionsPropType,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,9 +37,7 @@ export {
 export {
   MosaicContext,
   MosaicActionsPropType,
-  MosaicPathGetterPropType,
   MosaicRootActions,
-  MosaicTileContext,
   MosaicWindowActions,
   MosaicWindowActionsPropType,
   MosaicWindowContext,

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export {
   createHideUpdate,
   createRemoveUpdate,
   updateTree,
-} from './mosaicUpdates';
+} from './util/mosaicUpdates';
 export {
   createBalancedTreeFromLeaves,
   Corner,
@@ -62,7 +62,7 @@ export {
   getOtherDirection,
   getPathToCorner,
   isParent,
-} from './mosaicUtilities';
+} from './util/mosaicUtilities';
 export { MosaicWindow, MosaicWindowFactory, MosaicWindowProps } from './MosaicWindow';
 export {
   createDefaultToolbarButton,

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@
 
 /**
  * Valid node types
- * @see MosaicKey
+ * @see React.Key
  */
 export type MosaicKey = string | number;
 
@@ -63,8 +63,8 @@ export interface MosaicUpdate<T extends MosaicKey> {
 }
 
 /**
- * Mosaic needs a way to resolve `T` into react elements for display.
- * This provides a way to look them up. If `T` is a `JSX.Element`, then this can simply be `_.identity`
+ * Mosaic needs a way to resolve `MosaicKey` into react elements for display.
+ * This provides a way to render them.
  */
 export type TileRenderer<T extends MosaicKey> = (t: T, path: MosaicBranch[]) => JSX.Element;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,16 +16,22 @@
  */
 
 /**
+ * Valid node types
+ * @see MosaicKey
+ */
+export type MosaicKey = string | number;
+
+/**
  * Base type for the Mosaic binary tree
  */
-export type MosaicNode<T> = MosaicParent<T> | T;
+export type MosaicNode<T extends MosaicKey> = MosaicParent<T> | T;
 
 /**
  * Row means each window is side-by-side
  */
 export type MosaicDirection = 'row' | 'column';
 
-export interface MosaicParent<T> {
+export interface MosaicParent<T extends MosaicKey> {
   direction: MosaicDirection;
   first: MosaicNode<T>;
   second: MosaicNode<T>;
@@ -39,7 +45,7 @@ export type MosaicPath = MosaicBranch[];
  * Used by many utility methods to update the tree.
  * spec will be passed to https://github.com/kolodny/immutability-helper
  */
-export interface MosaicUpdateSpec<T> {
+export interface MosaicUpdateSpec<T extends MosaicKey> {
   $set?: MosaicNode<T>;
   splitPercentage?: {
     $set: number | null;
@@ -51,7 +57,7 @@ export interface MosaicUpdateSpec<T> {
   second?: MosaicUpdateSpec<T>;
 }
 
-export interface MosaicUpdate<T> {
+export interface MosaicUpdate<T extends MosaicKey> {
   path: MosaicPath;
   spec: MosaicUpdateSpec<T>;
 }
@@ -60,12 +66,12 @@ export interface MosaicUpdate<T> {
  * Mosaic needs a way to resolve `T` into react elements for display.
  * This provides a way to look them up. If `T` is a `JSX.Element`, then this can simply be `_.identity`
  */
-export type TileRenderer<T> = (t: T) => JSX.Element;
+export type TileRenderer<T extends MosaicKey> = (t: T, path: MosaicBranch[]) => JSX.Element;
 
 /**
  * Function that provides a new node to put into the tree
  */
-export type CreateNode<T> = (...args: any[]) => Promise<MosaicNode<T>> | MosaicNode<T>;
+export type CreateNode<T extends MosaicKey> = (...args: any[]) => Promise<MosaicNode<T>> | MosaicNode<T>;
 
 /**
  * Used by `react-dnd`

--- a/src/util/BoundingBox.ts
+++ b/src/util/BoundingBox.ts
@@ -17,6 +17,7 @@
 import { MosaicDirection } from '../types';
 import { assertNever } from './assertNever';
 
+// Each of these values is like the CSS property of the same name in percentages
 export interface BoundingBox {
   top: number;
   right: number;
@@ -36,21 +37,83 @@ export namespace BoundingBox {
 
   export interface Split {
     first: BoundingBox;
-    splitter: BoundingBox;
     second: BoundingBox;
   }
 
-  export function split({ top, right, bottom, left }: BoundingBox,
-                        splitPercentage: number, direction: MosaicDirection): Split {
-    const width = 100 - right - left;
-    const height = 100 - top - bottom;
+  export interface Styles {
+    top: string;
+    right: string;
+    bottom: string;
+    left: string;
+  }
 
+  export function split(boundingBox: BoundingBox,
+                        relativeSplitPercentage: number,
+                        direction: MosaicDirection): Split {
+    const absolutePercentage = getAbsoluteSplitPercentage(boundingBox, relativeSplitPercentage, direction);
     if (direction === 'column') {
-
+      return {
+        first: {
+          ...boundingBox,
+          bottom: 100 - absolutePercentage,
+        },
+        second: {
+          ...boundingBox,
+          top: absolutePercentage,
+        },
+      };
     } else if (direction === 'row') {
-
+      return {
+        first: {
+          ...boundingBox,
+          right: 100 - absolutePercentage,
+        },
+        second: {
+          ...boundingBox,
+          left: absolutePercentage,
+        },
+      };
     } else {
-      assertNever(direction);
+      return assertNever(direction);
     }
+  }
+
+  export function getAbsoluteSplitPercentage(boundingBox: BoundingBox,
+                                             relativeSplitPercentage: number,
+                                             direction: MosaicDirection): number {
+    const { top, right, bottom, left } = boundingBox;
+    if (direction === 'column') {
+      const height = 100 - top - bottom;
+      return height * relativeSplitPercentage / 100 + top;
+    } else if (direction === 'row') {
+      const width = 100 - right - left;
+      return width * relativeSplitPercentage / 100 + left;
+    } else {
+      return assertNever(direction);
+    }
+  }
+
+  export function getRelativeSplitPercentage(boundingBox: BoundingBox,
+                                             absoluteSplitPercentage: number,
+                                             direction: MosaicDirection): number {
+    const { top, right, bottom, left } = boundingBox;
+    if (direction === 'column') {
+      const height = 100 - top - bottom;
+      return (absoluteSplitPercentage - top) / height * 100;
+    } else if (direction === 'row') {
+      const width = 100 - right - left;
+      return (absoluteSplitPercentage - left) / width * 100;
+    } else {
+      return assertNever(direction);
+    }
+  }
+
+  export function asStyles({top, right, bottom, left}: BoundingBox): Styles {
+    return {
+      top: `${top}%`,
+      right: `${right}%`,
+      bottom: `${bottom}%`,
+      left: `${left}%`,
+    };
   }
 }

--- a/src/util/BoundingBox.ts
+++ b/src/util/BoundingBox.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { MosaicDirection } from '../types';
+import { assertNever } from './assertNever';
+
+export interface BoundingBox {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
+export namespace BoundingBox {
+  export function empty() {
+    return {
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    };
+  }
+
+  export interface Split {
+    first: BoundingBox;
+    splitter: BoundingBox;
+    second: BoundingBox;
+  }
+
+  export function split({ top, right, bottom, left }: BoundingBox,
+                        splitPercentage: number, direction: MosaicDirection): Split {
+    const width = 100 - right - left;
+    const height = 100 - top - bottom;
+
+    if (direction === 'column') {
+
+    } else if (direction === 'row') {
+
+    } else {
+      assertNever(direction);
+    }
+  }
+}

--- a/src/util/assertNever.ts
+++ b/src/util/assertNever.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export function assertNever(shouldBeNever: never): never {
+  throw new Error('Unhandled case: ' + JSON.stringify(shouldBeNever));
+}

--- a/src/util/mosaicUpdates.ts
+++ b/src/util/mosaicUpdates.ts
@@ -16,17 +16,18 @@
  */
 import * as update from 'immutability-helper';
 import * as _ from 'lodash';
-import { MosaicDropTargetPosition } from './internalTypes';
-import { getAndAssertNodeAtPathExists, getOtherBranch } from './mosaicUtilities';
+import { MosaicDropTargetPosition } from '../internalTypes';
 import {
   MosaicBranch,
   MosaicDirection,
+  MosaicKey,
   MosaicNode,
   MosaicParent,
   MosaicPath,
   MosaicUpdate,
   MosaicUpdateSpec,
-} from './types';
+} from '../types';
+import { getAndAssertNodeAtPathExists, getOtherBranch } from './mosaicUtilities';
 
 // https://github.com/Microsoft/TypeScript/issues/9944
 export { MosaicParent };
@@ -36,7 +37,7 @@ export { MosaicParent };
  * @param mosaicUpdate
  * @returns {any}
  */
-export function buildSpecFromUpdate<T>(mosaicUpdate: MosaicUpdate<T>): MosaicUpdateSpec<T> {
+export function buildSpecFromUpdate<T extends MosaicKey>(mosaicUpdate: MosaicUpdate<T>): MosaicUpdateSpec<T> {
   if (mosaicUpdate.path.length > 0) {
     return _.set({}, mosaicUpdate.path, mosaicUpdate.spec);
   } else {
@@ -50,7 +51,7 @@ export function buildSpecFromUpdate<T>(mosaicUpdate: MosaicUpdate<T>): MosaicUpd
  * @param updates
  * @returns {MosaicNode<T>}
  */
-export function updateTree<T>(root: MosaicNode<T>, updates: MosaicUpdate<T>[]) {
+export function updateTree<T extends MosaicKey>(root: MosaicNode<T>, updates: MosaicUpdate<T>[]) {
   let currentNode = root;
   updates.forEach((mUpdate: MosaicUpdate<T>) => {
     currentNode = update(currentNode, buildSpecFromUpdate(mUpdate));
@@ -65,7 +66,7 @@ export function updateTree<T>(root: MosaicNode<T>, updates: MosaicUpdate<T>[]) {
  * @param path
  * @returns {{path: T[], spec: {$set: MosaicNode<T>}}}
  */
-export function createRemoveUpdate<T>(root: MosaicNode<T> | null, path: MosaicPath): MosaicUpdate<T> {
+export function createRemoveUpdate<T extends MosaicKey>(root: MosaicNode<T> | null, path: MosaicPath): MosaicUpdate<T> {
   const parentPath = _.dropRight(path);
   const nodeToRemove = _.last(path);
   const siblingPath = parentPath.concat(getOtherBranch(nodeToRemove!));
@@ -92,10 +93,10 @@ function isPathPrefixEqual(a: MosaicPath, b: MosaicPath, length: number) {
  * @param position
  * @returns {(MosaicUpdate<T>|{path: MosaicPath, spec: {$set: {first: MosaicNode<T>, second: MosaicNode<T>, direction: MosaicDirection}}})[]}
  */
-export function createDragToUpdates<T>(root: MosaicNode<T>,
-                                       sourcePath: MosaicPath,
-                                       destinationPath: MosaicPath,
-                                       position: MosaicDropTargetPosition): MosaicUpdate<T>[] {
+export function createDragToUpdates<T extends MosaicKey>(root: MosaicNode<T>,
+                                                         sourcePath: MosaicPath,
+                                                         destinationPath: MosaicPath,
+                                                         position: MosaicDropTargetPosition): MosaicUpdate<T>[] {
   let destinationNode = getAndAssertNodeAtPathExists(root, destinationPath);
   const updates: MosaicUpdate<T>[] = [];
 
@@ -147,7 +148,7 @@ export function createDragToUpdates<T>(root: MosaicNode<T>,
  * @param path
  * @returns {{path: T[], spec: {splitPercentage: {$set: number}}}}
  */
-export function createHideUpdate<T>(path: MosaicPath): MosaicUpdate<T> {
+export function createHideUpdate<T extends MosaicKey>(path: MosaicPath): MosaicUpdate<T> {
   const targetPath = _.dropRight(path);
   const thisBranch = _.last(path);
 
@@ -174,7 +175,7 @@ export function createHideUpdate<T>(path: MosaicPath): MosaicUpdate<T> {
  * @param percentage
  * @returns {{spec: MosaicUpdateSpec<T>, path: Array}}
  */
-export function createExpandUpdate<T>(path: MosaicPath, percentage: number): MosaicUpdate<T> {
+export function createExpandUpdate<T extends MosaicKey>(path: MosaicPath, percentage: number): MosaicUpdate<T> {
   let spec: MosaicUpdateSpec<T> = {};
   for (let i = path.length - 1; i >= 0; i--) {
     const branch: MosaicBranch = path[i];

--- a/src/util/mosaicUtilities.ts
+++ b/src/util/mosaicUtilities.ts
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 import * as _ from 'lodash';
-import { MosaicBranch, MosaicDirection, MosaicNode, MosaicParent, MosaicPath } from './types';
+import { MosaicBranch, MosaicDirection, MosaicKey, MosaicNode, MosaicParent, MosaicPath } from '../types';
 
-function alternateDirection<T>(node: MosaicNode<T>, direction: MosaicDirection = 'row'): MosaicNode<T> {
+function alternateDirection<T extends MosaicKey>(node: MosaicNode<T>, direction: MosaicDirection = 'row'): MosaicNode<T> {
   if (isParent(node)) {
     const nextDirection = getOtherDirection(direction);
     return {
@@ -42,7 +42,7 @@ export enum Corner {
  * @param node
  * @returns {boolean}
  */
-export function isParent<T>(node: MosaicNode<T>): node is MosaicParent<T> {
+export function isParent<T extends MosaicKey>(node: MosaicNode<T>): node is MosaicParent<T> {
   return (node as MosaicParent<T>).direction != null;
 }
 
@@ -52,8 +52,8 @@ export function isParent<T>(node: MosaicNode<T>): node is MosaicParent<T> {
  * @param startDirection
  * @returns {MosaicNode<T>}
  */
-export function createBalancedTreeFromLeaves<T>(leaves: MosaicNode<T>[],
-                                                startDirection: MosaicDirection = 'row'): MosaicNode<T> | null {
+export function createBalancedTreeFromLeaves<T extends MosaicKey>(leaves: MosaicNode<T>[],
+                                                                  startDirection: MosaicDirection = 'row'): MosaicNode<T> | null {
   if (leaves.length === 0) {
     return null;
   }
@@ -137,7 +137,7 @@ export function getPathToCorner(tree: MosaicNode<any>, corner: Corner): MosaicPa
  * @param tree
  * @returns {T[]}
  */
-export function getLeaves<T>(tree: MosaicNode<T> | null): T[] {
+export function getLeaves<T extends MosaicKey>(tree: MosaicNode<T> | null): T[] {
   if (tree == null) {
     return [];
   } else if (isParent(tree)) {
@@ -154,7 +154,7 @@ export function getLeaves<T>(tree: MosaicNode<T> | null): T[] {
  * @param path
  * @returns {MosaicNode<T>|null}
  */
-export function getNodeAtPath<T>(tree: MosaicNode<T> | null, path: MosaicPath): MosaicNode<T> | null {
+export function getNodeAtPath<T extends MosaicKey>(tree: MosaicNode<T> | null, path: MosaicPath): MosaicNode<T> | null {
   if (path.length > 0) {
     return _.get<MosaicNode<T>>(tree, path, null!);
   } else {
@@ -168,7 +168,7 @@ export function getNodeAtPath<T>(tree: MosaicNode<T> | null, path: MosaicPath): 
  * @param path
  * @returns {MosaicNode<T>}
  */
-export function getAndAssertNodeAtPathExists<T>(tree: MosaicNode<T> | null, path: MosaicPath): MosaicNode<T> {
+export function getAndAssertNodeAtPathExists<T extends MosaicKey>(tree: MosaicNode<T> | null, path: MosaicPath): MosaicNode<T> {
   if (tree == null) {
     throw new Error('Root is empty, cannot fetch path');
   }

--- a/styles/blueprint-theme.less
+++ b/styles/blueprint-theme.less
@@ -16,7 +16,7 @@
  */
 @import (reference) '../node_modules/@blueprintjs/core/dist/variables';
 
-.mosaic-root.mosaic-blueprint-theme {
+.mosaic.mosaic-blueprint-theme {
   background: @gray4;
 
   .mosaic-zero-state {
@@ -25,7 +25,7 @@
     box-shadow: @pt-elevation-shadow-0;
   }
 
-  .mosaic-tile .mosaic-split:hover {
+  .mosaic-split:hover {
     background: none;
     .mosaic-split-line {
       box-shadow: 0 0 0 1px @blue4;
@@ -115,7 +115,7 @@
       box-shadow: @pt-dark-elevation-shadow-0;
     }
 
-    .mosaic-tile .mosaic-split:hover .mosaic-split-line {
+    .mosaic-split:hover .mosaic-split-line {
       box-shadow: 0 0 0 1px @blue3;
     }
 

--- a/styles/mosaic-window.less
+++ b/styles/mosaic-window.less
@@ -129,7 +129,7 @@
   }
 }
 
-.mosaic-root:not(.mosaic-blueprint-theme) {
+.mosaic:not(.mosaic-blueprint-theme) {
   .mosaic-default-control {
     &.pt-icon-cross:before {
       content: 'Close';

--- a/styles/mosaic.less
+++ b/styles/mosaic.less
@@ -18,122 +18,77 @@
 
 @split-size: 6px;
 
-.mosaic-root {
+.mosaic {
   height: 100%;
   width: 100%;
-  padding: @split-size;
 
   &, * {
     box-sizing: border-box;
   }
 
   .mosaic-zero-state {
-    height: 100%;
-    width: 100%;
+    width: auto;
+    height: auto;
     max-width: none;
+    z-index: 1;
 
     .pt-non-ideal-state-icon .pt-icon {
       font-size: 120px;
     }
   }
-
-  > :not(.drop-target-container) {
-    z-index: 1;
-    position: relative;
-    height: 100%;
-    width: 100%;
-  }
 }
 
-.mosaic-tile {
-  position: relative;
+.mosaic-root {
+  @size: @split-size / 2;
+  .absolute-fill(@size, @size, @size, @size);
+}
 
-  .mosaic-branch {
-    position: absolute;
+.mosaic-split {
+  position: absolute;
+  z-index: 1;
 
-    > * {
-      height: 100%;
-      width: 100%;
-    }
+  &:hover {
+    background: black;
   }
 
-  .mosaic-split {
+  .mosaic-split-line {
     position: absolute;
-    z-index: 1;
-
-    &:hover {
-      background: black;
-    }
-
-    .mosaic-split-line {
-      position: absolute;
-    }
   }
 
   &.-row {
-    > .mosaic-branch, > .mosaic-split {
+    margin-left: -@split-size / 2;
+    width: @split-size;
+    cursor: ew-resize;
+
+    .mosaic-split-line {
       top: 0;
       bottom: 0;
-    }
-    > .mosaic-branch {
-      &.-first {
-        left: 0;
-        &, > .mosaic-tile {
-          padding-right: @split-size / 2;
-        }
-      }
-      &.-second {
-        right: 0;
-        &, > .mosaic-tile {
-          padding-left: @split-size / 2;
-        }
-      }
-    }
-    > .mosaic-split {
-      margin-left: -@split-size / 2;
-      width: @split-size;
-      cursor: ew-resize;
-
-      .mosaic-split-line {
-        top: 0;
-        bottom: 0;
-        left: @split-size / 2;
-        right: @split-size / 2;
-      }
+      left: @split-size / 2;
+      right: @split-size / 2;
     }
   }
 
   &.-column {
-    > .mosaic-branch, > .mosaic-split {
+    margin-top: -@split-size / 2;
+    height: @split-size;
+    cursor: ns-resize;
+
+    .mosaic-split-line {
+      top: @split-size / 2;
+      bottom: @split-size / 2;
       left: 0;
       right: 0;
     }
-    > .mosaic-branch {
-      &.-first {
-        top: 0;
-        &, > .mosaic-tile {
-          padding-bottom: @split-size / 2;
-        }
-      }
-      &.-second {
-        bottom: 0;
-        &, > .mosaic-tile {
-          padding-top: @split-size / 2;
-        }
-      }
-    }
-    > .mosaic-split {
-      margin-top: -@split-size / 2;
-      height: @split-size;
-      cursor: ns-resize;
+  }
+}
 
-      .mosaic-split-line {
-        top: @split-size / 2;
-        bottom: @split-size / 2;
-        left: 0;
-        right: 0;
-      }
-    }
+.mosaic-tile {
+  position: absolute;
+  margin: @split-size / 2;
+
+  > * {
+    height: 100%;
+    width: 100%;
   }
 }
 

--- a/test/boundingBoxSpec.ts
+++ b/test/boundingBoxSpec.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from 'chai';
+import { BoundingBox } from '../src/util/BoundingBox';
+
+// Yay javascript float precision
+function expectBoundingBoxCloseTo(a: BoundingBox, b: BoundingBox, delta: number = 0.000001) {
+  expect(a.top).to.be.closeTo(b.top, delta);
+  expect(a.right).to.be.closeTo(b.right, delta);
+  expect(a.bottom).to.be.closeTo(b.bottom, delta);
+  expect(a.left).to.be.closeTo(b.left, delta);
+}
+
+describe('BoundingBox', () => {
+  describe('Root', () => {
+    const EMPTY = BoundingBox.empty();
+    it('should split column', () => {
+      const { first, second } = BoundingBox.split(EMPTY, 25, 'column');
+      expectBoundingBoxCloseTo(first, {
+        top: 0,
+        right: 0,
+        bottom: 75,
+        left: 0,
+      });
+      expectBoundingBoxCloseTo(second, {
+        top: 25,
+        right: 0,
+        bottom: 0,
+        left: 0,
+      });
+    });
+    it('should split row', () => {
+      const { first, second } = BoundingBox.split(EMPTY, 25, 'row');
+      expectBoundingBoxCloseTo(first, {
+        top: 0,
+        right: 75,
+        bottom: 0,
+        left: 0,
+      });
+      expectBoundingBoxCloseTo(second, {
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 25,
+      });
+    });
+  });
+  describe('Complex', () => {
+    const COMPLEX = {
+      top: 100 / 6,
+      right: 100 / 6,
+      bottom: 100 / 6,
+      left: 100 / 6,
+    };
+    it('should split column', () => {
+      const { first, second } = BoundingBox.split(COMPLEX, 25, 'column');
+      expectBoundingBoxCloseTo(first, {
+        top: 100 / 6,
+        right: 100 / 6,
+        bottom: 100 / 6 * 4,
+        left: 100 / 6,
+      });
+      expectBoundingBoxCloseTo(second, {
+        top: 100 / 6 * 2,
+        right: 100 / 6,
+        bottom: 100 / 6,
+        left: 100 / 6,
+      });
+    });
+  });
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,3 @@
 --reporter spec
---compilers ts:./test/registerTsNode,tsx:./test/registerTsNode
+--require ./test/registerTsNode
 --require jsdom-global/register

--- a/test/updatesSpec.ts
+++ b/test/updatesSpec.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { getNodeAtPath, MosaicNode } from '../src/index';
 import { MosaicDropTargetPosition } from '../src/internalTypes';
-import { createDragToUpdates, createRemoveUpdate, updateTree } from '../src/mosaicUpdates';
+import { createDragToUpdates, createRemoveUpdate, updateTree } from '../src/util/mosaicUpdates';
 import { MosaicParent, MosaicPath } from '../src/types';
 
 const MEDIUM_TREE: MosaicNode<number> = {

--- a/test/utilitiesSpec.ts
+++ b/test/utilitiesSpec.ts
@@ -24,7 +24,7 @@ import {
     getLeaves,
     getPathToCorner,
     isParent,
-} from '../src/mosaicUtilities';
+} from '../src/util/mosaicUtilities';
 
 const ROOT_ONLY_TREE: MosaicNode<number> = 1;
 const MEDIUM_TREE: MosaicNode<number> = {

--- a/tslint.json
+++ b/tslint.json
@@ -15,6 +15,7 @@
     },
     "member-access": false,
     "member-ordering": false,
+    "no-namespace": false,
     "object-literal-sort-keys": false,
     "quotemark": {
       "options": "single"


### PR DESCRIPTION
Fixes #2 
Fixes #3 

## BLUF
Mosaic now renders a flattened version of the provided tree. This means that layout changes no longer force components to unmount and remount. Component state will be preserved and time will not be wasted rerendering.

## Breaking Changes
- DOM structure is very different - highly likely to cause problems with custom styles
  - Rendered structure is now flat
  - `.mosaic-root` class renamed to `.mosaic`
- `T` now must extend `MosaicKey` (`string` or `number`) so that they can be used as a (`React.Key`)[https://reactjs.org/docs/lists-and-keys.html]
- `getMosaicPath` has been moved to `MosaicWindowActions` as `getPath`
- `TileRenderer` is now also passed the current path `MosaicBranch[]`
- `MosaicWindow` now requires the `path: MosaicBranch[]` prop

## Other Notes
- `T` now defaults to `string`
 