### PR TITLE
Fix RemoveButton example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ class RemoveButton extends React.PureComponent<Props> {
     }
 
     private remove = () =>
-        this.context.mosaicActions.remove(this.context.getMosaicPath());
+        this.context.mosaicActions.remove(this.context.mosaicWindowActions.getPath());
 }
 ```
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

`getMosaicPath` has been removed and can be replaced by `mosaicWindowActions.getPath`, this PR fix the README that is still referencing `getMosaicPath` :)

#### Reviewers should focus on:

If the change is correct or not, should be ok as I tested it on my project.

#### Screenshot

N/A

Thanks for your awesome library, it's super useful! 👍  Using it in https://github.com/4ian/GD ❤️ 