### PR TITLE
Fix isDragging set to true even when a non Mosaic Window is dragged

### DIFF
--- a/src/RootDropTargets.tsx
+++ b/src/RootDropTargets.tsx
@@ -32,5 +32,5 @@ class RootDropTargetsClass extends React.PureComponent<RootDropTargetsProps> {
 
 const dropTarget = {};
 export const RootDropTargets = DropTarget(MosaicDragType.WINDOW, dropTarget, (_connect, monitor): RootDropTargetsProps => ({
-  isDragging: monitor.getItem() !== null,
+  isDragging: monitor.getItem() !== null && monitor.getItemType() === MosaicDragType.WINDOW,
 }))(RootDropTargetsClass) as React.ComponentClass<{}>;


### PR DESCRIPTION
#### Changes proposed in this pull request:

`isDragging` props of RootDropTargetsClass (and `-dragging` css class) is set to true even when the dragged item is not a `MosaicDragType.WINDOW`. This can be an issue as I have other `DropTarget` from `react-dnd` in my app, and when I drag anything else that is not a Window, RootDropTargetsClass is blocking the drag as it's displayed as a block. 

The PR ensure that the container remains hidden when the dragged item is not a `MosaicDragType.WINDOW`.

#### Reviewers should focus on:

Is this breaking anything? :) Tested on the demo and everything looks still good.

#### Screenshot

N/A
