### PR TITLE
Use ~ to resolve blueprintjs variables stylesheet

### DIFF
--- a/styles/blueprint-theme.less
+++ b/styles/blueprint-theme.less
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@import (reference) '../node_modules/@blueprintjs/core/dist/variables';
+@import (reference) '~@blueprintjs/core/dist/variables';
 
 .mosaic.mosaic-blueprint-theme {
   background: @gray4;


### PR DESCRIPTION
#### Fixes #0000

When using nwb, I get this error :

```
Failed to compile with 1 error.
 ERROR  in ./node_modules/react-mosaic-component/styles/index.less
Module build failed:

 */
@import (reference) '../node_modules/@blueprintjs/core/dist/variables';
^
Can't resolve '../node_modules/@blueprintjs/core/dist/variables.less' in '/Users/cvidal/Documents/Personnel/Trading/crypto-stoploss-bot/ui/node_modules/react-mosaic-component/styles'
      in /Users/cvidal/Documents/Personnel/Trading/crypto-stoploss-bot/ui/node_modules/react-mosaic-component/styles/blueprint-theme.less (line 17, column 0)
 @ ./node_modules/react-mosaic-component/styles/index.less 4:14-289 18:2-22:4 19:20-295
 @ ./src/Home.js
 @ ./src/App.js
 @ ./src/index.js
 @ multi /usr/local/lib/node_modules/nwb/polyfills.js (webpack)-dev-server/client?/ (webpack)/hot/only-dev-server.js ./src/index.js
```
#### Changes proposed in this pull request:

Use ~ to resolve blueprintjs variables stylesheet to make the resolution not depend on ../node_modules which breaks with nwb (and possibly other contexts).
