### PR TITLE
Remove hard dep on blueprint via webpack dynamic import

### DIFF
--- a/src/MosaicZeroState.tsx
+++ b/src/MosaicZeroState.tsx
@@ -14,10 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Classes, Icon } from '@blueprintjs/core';
-import { IconNames } from '@blueprintjs/icons';
-import classNames from 'classnames';
 import noop from 'lodash/noop';
+import { BlueprintCoreMock as BlueprintCore } from './util/BlueprintCoreMock';
+import('@blueprintjs/core')
+  .then(({ default: _ }) => {
+    BlueprintCore.Classes = _.Classes;
+    BlueprintCore.Icon = _.Icon;
+  })
+  .catch((_error) => noop);
+
+import { BlueprintIconsMock as BlueprintIcons } from './util/BlueprintIconsMock';
+import('@blueprintjs/icons')
+  .then(({ default: _ }) => {
+    BlueprintCore.IconNames = _.IconNames;
+  })
+  .catch((_error) => noop);
+import classNames from 'classnames';
 import React from 'react';
 
 import { MosaicActionsPropType, MosaicContext } from './contextTypes';
@@ -36,14 +48,20 @@ export class MosaicZeroState<T extends MosaicKey> extends React.PureComponent<Mo
 
   render() {
     return (
-      <div className={classNames('mosaic-zero-state', Classes.NON_IDEAL_STATE)}>
-        <div className={Classes.NON_IDEAL_STATE_VISUAL}>
-          <Icon iconSize={120} icon="applications" />
+      <div className={classNames('mosaic-zero-state', BlueprintCore.Classes.NON_IDEAL_STATE)}>
+        <div className={BlueprintCore.Classes.NON_IDEAL_STATE_VISUAL}>
+          <BlueprintCore.Icon iconSize={120} icon="applications" />
         </div>
-        <h4 className={Classes.HEADING}>No Windows Present</h4>
+        <h4 className={BlueprintCore.Classes.HEADING}>No Windows Present</h4>
         <div>
           {this.props.createNode && (
-            <button className={classNames(Classes.BUTTON, Classes.iconClass(IconNames.ADD))} onClick={this.replace}>
+            <button
+              className={classNames(
+                BlueprintCore.Classes.BUTTON,
+                BlueprintCore.Classes.iconClass(BlueprintIcons.IconNames.ADD),
+              )}
+              onClick={this.replace}
+            >
               Add New Window
             </button>
           )}

--- a/src/util/BlueprintCoreMock.tsx
+++ b/src/util/BlueprintCoreMock.tsx
@@ -1,0 +1,325 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+export class BlueprintCoreMock {
+  public static Classes = {
+    ACTIVE: '',
+    ALIGN_LEFT: '',
+    ALIGN_RIGHT: '',
+    CONDENSED: '',
+    DARK: '',
+    DISABLED: '',
+    FILL: '',
+    FIXED: '',
+    FIXED_TOP: '',
+    INLINE: '',
+    INTERACTIVE: '',
+    LARGE: '',
+    LOADING: '',
+    MINIMAL: '',
+    MULTILINE: '',
+    ROUND: '',
+    SMALL: '',
+    VERTICAL: '',
+
+    ELEVATION_0: '',
+    ELEVATION_1: '',
+    ELEVATION_2: '',
+    ELEVATION_3: '',
+    ELEVATION_4: '',
+
+    INTENT_PRIMARY: '',
+    INTENT_SUCCESS: '',
+    INTENT_WARNING: '',
+    INTENT_DANGER: '',
+
+    FOCUS_DISABLED: '',
+
+    // text utilities
+    UI_TEXT: '',
+    RUNNING_TEXT: '',
+    MONOSPACE_TEXT: '',
+    TEXT_LARGE: '',
+    TEXT_SMALL: '',
+    TEXT_MUTED: '',
+    TEXT_DISABLED: '',
+    TEXT_OVERFLOW_ELLIPSIS: '',
+
+    // textual elements
+    BLOCKQUOTE: '',
+    CODE: '',
+    CODE_BLOCK: '',
+    HEADING: '',
+    LIST: '',
+    LIST_UNSTYLED: '',
+    RTL: '',
+
+    // components
+    ALERT: '',
+    ALERT_BODY: '',
+    ALERT_CONTENTS: '',
+    ALERT_FOOTER: '',
+
+    BREADCRUMB: '',
+    BREADCRUMB_CURRENT: '',
+    BREADCRUMBS: '',
+    BREADCRUMBS_COLLAPSED: '',
+
+    BUTTON: '',
+    BUTTON_GROUP: '',
+    BUTTON_SPINNER: '',
+    BUTTON_TEXT: '',
+
+    CALLOUT: '',
+    CALLOUT_ICON: '',
+
+    CARD: '',
+
+    COLLAPSE: '',
+    COLLAPSE_BODY: '',
+
+    COLLAPSIBLE_LIST: '',
+
+    CONTEXT_MENU: '',
+    CONTEXT_MENU_POPOVER_TARGET: '',
+
+    CONTROL_GROUP: '',
+
+    DIALOG: '',
+    DIALOG_CONTAINER: '',
+    DIALOG_BODY: '',
+    DIALOG_CLOSE_BUTTON: '',
+    DIALOG_FOOTER: '',
+    DIALOG_FOOTER_ACTIONS: '',
+    DIALOG_HEADER: '',
+
+    DIVIDER: '',
+
+    EDITABLE_TEXT: '',
+    EDITABLE_TEXT_CONTENT: '',
+    EDITABLE_TEXT_EDITING: '',
+    EDITABLE_TEXT_INPUT: '',
+    EDITABLE_TEXT_PLACEHOLDER: '',
+
+    FLEX_EXPANDER: '',
+
+    HTML_SELECT: '',
+    /** @deprecated prefer `<HTMLSelect>` component */
+    SELECT: '',
+
+    HTML_TABLE: '',
+    HTML_TABLE_STRIPED: '',
+    HTML_TABLE_BORDERED: '',
+
+    INPUT: '',
+    INPUT_GHOST: '',
+    INPUT_GROUP: '',
+    INPUT_ACTION: '',
+
+    CONTROL: '',
+    CONTROL_INDICATOR: '',
+    CHECKBOX: '',
+    RADIO: '',
+    SWITCH: '',
+    FILE_INPUT: '',
+    FILE_UPLOAD_INPUT: '',
+
+    KEY: '',
+    KEY_COMBO: '',
+    MODIFIER_KEY: '',
+
+    HOTKEY: '',
+    HOTKEY_LABEL: '',
+    HOTKEY_COLUMN: '',
+    HOTKEY_DIALOG: '',
+
+    LABEL: '',
+    FORM_GROUP: '',
+    FORM_CONTENT: '',
+    FORM_HELPER_TEXT: '',
+
+    MENU: '',
+    MENU_ITEM: '',
+    MENU_ITEM_LABEL: '',
+    MENU_SUBMENU: '',
+    MENU_DIVIDER: '',
+    MENU_HEADER: '',
+
+    NAVBAR: '',
+    NAVBAR_GROUP: '',
+    NAVBAR_HEADING: '',
+    NAVBAR_DIVIDER: '',
+
+    NON_IDEAL_STATE: '',
+    NON_IDEAL_STATE_VISUAL: '',
+
+    NUMERIC_INPUT: '',
+
+    OVERFLOW_LIST: '',
+    OVERFLOW_LIST_SPACER: '',
+
+    OVERLAY: '',
+    OVERLAY_BACKDROP: '',
+    OVERLAY_CONTENT: '',
+    OVERLAY_INLINE: '',
+    OVERLAY_OPEN: '',
+    OVERLAY_SCROLL_CONTAINER: '',
+
+    PANEL_STACK: '',
+    PANEL_STACK_HEADER: '',
+    PANEL_STACK_HEADER_BACK: '',
+    PANEL_STACK_VIEW: '',
+
+    POPOVER: '',
+    POPOVER_ARROW: '',
+    POPOVER_BACKDROP: '',
+    POPOVER_CONTENT: '',
+    POPOVER_CONTENT_SIZING: '',
+    POPOVER_DISMISS: '',
+    POPOVER_DISMISS_OVERRIDE: '',
+    POPOVER_OPEN: '',
+    POPOVER_TARGET: '',
+    POPOVER_WRAPPER: '',
+    TRANSITION_CONTAINER: '',
+
+    PROGRESS_BAR: '',
+    PROGRESS_METER: '',
+    PROGRESS_NO_STRIPES: '',
+    PROGRESS_NO_ANIMATION: '',
+
+    PORTAL: '',
+
+    SKELETON: '',
+
+    SLIDER: '',
+    SLIDER_AXIS: '',
+    SLIDER_HANDLE: '',
+    SLIDER_LABEL: '',
+    SLIDER_TRACK: '',
+    SLIDER_PROGRESS: '',
+    START: '',
+    END: '',
+
+    SPINNER: '',
+    SPINNER_ANIMATION: '',
+    SPINNER_HEAD: '',
+    SPINNER_NO_SPIN: '',
+    SPINNER_TRACK: '',
+
+    TAB: '',
+    TAB_INDICATOR: '',
+    TAB_INDICATOR_WRAPPER: '',
+    TAB_LIST: '',
+    TAB_PANEL: '',
+    TABS: '',
+
+    TAG: '',
+    TAG_REMOVE: '',
+
+    TAG_INPUT: '',
+    TAG_INPUT_ICON: '',
+    TAG_INPUT_VALUES: '',
+
+    TOAST: '',
+    TOAST_CONTAINER: '',
+    TOAST_MESSAGE: '',
+
+    TOOLTIP: '',
+    TOOLTIP_INDICATOR: '',
+
+    TREE: '',
+    TREE_NODE: '',
+    TREE_NODE_CARET: '',
+    TREE_NODE_CARET_CLOSED: '',
+    TREE_NODE_CARET_NONE: '',
+    TREE_NODE_CARET_OPEN: '',
+    TREE_NODE_CONTENT: '',
+    TREE_NODE_EXPANDED: '',
+    TREE_NODE_ICON: '',
+    TREE_NODE_LABEL: '',
+    TREE_NODE_LIST: '',
+    TREE_NODE_SECONDARY_LABEL: '',
+    TREE_NODE_SELECTED: '',
+    TREE_ROOT: '',
+
+    ICON: '',
+    ICON_STANDARD: '',
+    ICON_LARGE: '',
+
+    getClassNamespace(): string {
+      return '';
+    },
+
+    alignmentClass(_alignment: 'center' | 'left' | 'right'): string {
+      return '';
+    },
+
+    elevationClass(_elevation: 0 | 1 | 2 | 3 | 4): string {
+      return '';
+    },
+
+    iconClass(_iconName?: string): string {
+      return '';
+    },
+
+    intentClass(_intent?: 'none' | 'primary' | 'warning' | 'success' | 'danger'): string {
+      return '';
+    },
+  };
+
+  public static IconNames = {
+    ADD: '',
+  };
+
+  public static Icon = class extends React.PureComponent<IconProps & React.DOMAttributes<HTMLElement>> {
+    public render(): React.ReactNode {
+      return <span />;
+    }
+  };
+}
+
+const Intent = {
+  NONE: 'none' as 'none',
+  PRIMARY: 'primary' as 'primary',
+  SUCCESS: 'success' as 'success',
+  WARNING: 'warning' as 'warning',
+  DANGER: 'danger' as 'danger',
+};
+
+type Intent = typeof Intent[keyof typeof Intent];
+
+// tslint:disable-next-line:interface-name
+interface IProps {
+  className?: string;
+}
+
+// tslint:disable-next-line:interface-name
+interface IIntentProps {
+  intent?: Intent;
+}
+
+interface IconProps extends IIntentProps, IProps {
+  children?: never;
+  color?: string;
+  icon: string | JSX.Element | false | null | undefined;
+  iconSize?: number;
+  style?: React.CSSProperties;
+  tagName?: keyof JSX.IntrinsicElements;
+  title?: string | false | null;
+}

--- a/src/util/BlueprintIconsMock.tsx
+++ b/src/util/BlueprintIconsMock.tsx
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2016 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class BlueprintIconsMock {
+  public static IconNames = {
+    ADD: '',
+  };
+}


### PR DESCRIPTION
#### Fixes #88 

#### Changes proposed in this pull request:

Since we can't use simple classnames anymore, I'm using webpack's dynamic imports to load blueprint if it exists and fallback to a 'mock' if it doesn't. Typescript's contextual inference helps out to ensure that the mock's type matches.

#### Reviewers should focus on:

I just updated `MosaicZeroState` - that seemed to be enough to get things working in my local tests but I'm unsure if I should update other classes. Let me know if this approach makes sense...

NOTE: After an update I'm not able to run any npm commands locally because of this issue: https://github.com/isaacs/node-graceful-fs/issues/139 
