### PR TITLE
Fixes #98 by creating a prop that takes a custom toolbar rendering method

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,10 @@ export interface MosaicWindowProps<T extends MosaicKey> {
    * Optional method to override the displayed preview when a user drags a window
    */
   renderPreview?: (props: MosaicWindowProps<T>) => JSX.Element;
+  /**
+   * Optional method to override the displayed toolbar
+   */
+  renderToolbar?: ((props: MosaicWindowProps<T>, draggable: boolean | undefined) => JSX.Element) | null;
 }
 ```
 

--- a/demo/ExampleApp.tsx
+++ b/demo/ExampleApp.tsx
@@ -96,6 +96,7 @@ export class ExampleApp extends React.PureComponent<{}, ExampleAppState> {
               title={`Window ${count}`}
               createNode={this.createNode}
               path={path}
+              renderToolbar={count === 2 ? () => <div>My Custom Toolbar</div> : null}
             >
               <div className="example-window">
                 <h1>{`Window ${count}`}</h1>

--- a/src/MosaicWindow.tsx
+++ b/src/MosaicWindow.tsx
@@ -51,6 +51,7 @@ export interface MosaicWindowProps<T extends MosaicKey> {
   draggable?: boolean;
   createNode?: CreateNode<T>;
   renderPreview?: (props: MosaicWindowProps<T>) => JSX.Element;
+  renderToolbar?: ((props: MosaicWindowProps<T>, draggable: boolean | undefined) => JSX.Element) | null;
 }
 
 export interface InternalDragSourceProps {
@@ -98,6 +99,7 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.Component<
         </div>
       </div>
     ),
+    renderToolbar: null,
   };
 
   static contextTypes = MosaicContext;
@@ -174,9 +176,27 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.Component<
   }
 
   private renderToolbar() {
-    const { title, draggable, additionalControls, additionalControlButtonText, connectDragSource, path } = this.props;
+    const {
+      title,
+      draggable,
+      additionalControls,
+      additionalControlButtonText,
+      connectDragSource,
+      path,
+      renderToolbar,
+    } = this.props;
     const { additionalControlsOpen } = this.state;
     const toolbarControls = this.getToolbarControls();
+    const draggableAndNotRoot = draggable && path.length > 0;
+
+    if (renderToolbar) {
+      const connectedToolbar = connectDragSource(renderToolbar(this.props, draggable)) as React.ReactElement<any>;
+      return (
+        <div className={classNames('mosaic-window-toolbar', { draggable: draggableAndNotRoot })}>
+          {connectedToolbar}
+        </div>
+      );
+    }
 
     let titleDiv: React.ReactElement<any> = (
       <div title={title} className="mosaic-window-title">
@@ -184,7 +204,6 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.Component<
       </div>
     );
 
-    const draggableAndNotRoot = draggable && path.length > 0;
     if (draggableAndNotRoot) {
       titleDiv = connectDragSource(titleDiv) as React.ReactElement<any>;
     }


### PR DESCRIPTION
#### Fixes #98

#### Changes proposed in this pull request:
This PR adds a new optional prop `renderToolbar` that can render an element passed in as a draggable toolbar.
#### Reviewers should focus on:
The name of the prop here might need a change. I went for consistency with the `renderPreview` method, but it also now shares a name with the private method. I'm totally open to suggestions of alternative naming. 
#### Screenshot
![draggable](https://user-images.githubusercontent.com/1656824/52884210-9fbf1b80-312a-11e9-8d40-6091e375d928.gif)
