### PR TITLE
Setup draggable to be provided via context

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,10 @@ export interface MosaicWindowActions {
    * Returns the path to this window
    */
   getPath: () => MosaicPath;
+  /**
+   * Enables connecting a different drag source besides the react-mosaic toolbar
+   */
+  connectDragSource: (connectedElements: React.ReactElement<any>) => React.ReactElement<any>;
 }
 ```
 

--- a/src/MosaicWindow.tsx
+++ b/src/MosaicWindow.tsx
@@ -122,6 +122,7 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.Component<
         replaceWithNew: this.swap,
         setAdditionalControlsOpen: this.setAdditionalControlsOpen,
         getPath: this.getPath,
+        connectDragSource: this.connectDragSource,
       },
     };
   }
@@ -277,6 +278,11 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.Component<
   };
 
   private getPath = () => this.props.path;
+
+  private connectDragSource = (connectedElements: React.ReactElement<any>) => {
+    const { connectDragSource } = this.props;
+    return connectDragSource(connectedElements);
+  };
 }
 
 const dragSource = {

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -95,6 +95,10 @@ export interface MosaicWindowActions {
    * Returns the path to this window
    */
   getPath: () => MosaicPath;
+  /**
+   * Enables connecting a different drag source besides the react-mosaic toolbar
+   */
+  connectDragSource: (connectedElements: React.ReactElement<any>) => React.ReactElement<any>;
 }
 
 /*************************************************************
@@ -115,6 +119,7 @@ export const MosaicWindowActionsPropType = PropTypes.shape({
   replaceWithNew: PropTypes.func.isRequired,
   setAdditionalControlsOpen: PropTypes.func.isRequired,
   getPath: PropTypes.func.isRequired,
+  connectDragSource: PropTypes.func.isRequired,
 }).isRequired;
 
 /*************************************************************


### PR DESCRIPTION
#### Fixes #101

#### Changes proposed in this pull request:

This PR adds the ability to connect a drag source that is not the `react-mosaic-toolbar`. Likely more powerful than #100 and gives adopters more flexibility.

#### Screenshot

Our local implementation now allows us to do the following within our own layout:

![draggable mosaic](https://user-images.githubusercontent.com/1656824/53132850-57d73480-352e-11e9-90d2-929cabcc3cdc.gif)

Where previously we had to use the provided toolbar or change our layout.

